### PR TITLE
Add quote's for hash keys

### DIFF
--- a/manifests/key_entry.pp
+++ b/manifests/key_entry.pp
@@ -8,8 +8,8 @@ define ssh::key_entry (
   if $key {
     ssh_authorized_key { "${user}-key-${ensure}-in-${owner}@${::hostname}":
       ensure => $ensure,
-      key    => $key[public_key],
-      type   => $key[type],
+      key    => $key['public_key'],
+      type   => $key['type'],
       user   => $owner,
     }
   }


### PR DESCRIPTION
Puppet 3.8 and higeher are more strict on using quotes. This change fixes using quote's on accesssing the Hash and makes this code compatible with Puppet 3.8 and higher
